### PR TITLE
Array of objects with oneOf prop

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -360,7 +360,7 @@ if (typeof brutusin === "undefined") {
                 option.value = s.oneOf[i];
                 appendChild(option, textNode, s);
                 appendChild(input, option, s);
-                if (value === undefined)
+                if (value === undefined || value === null)
                     continue;
                 if (s.readOnly)
                     input.disabled = true;


### PR DESCRIPTION
Fixing a bug where having `oneOf` prop on an object, in an array, causes json-forms.js to throw a hasOwnProperty of null exception. Code to reproduce:

```
"resources": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "name": {
            "type": "string"
          },
          "type": {
            "type": "object",
            "oneOf": [
              {
                "type": "array",
                "title": "External stylesheet",
                "items": {
                  "type": "object",
                  "properties": {
                    "url": {
                      "type": "string"
                    }
                  }
                }
              },
              {
                "title": "Inline stylesheet",
                "type": "array",
                "items": {
                  "type": "object",
                  "properties": {
                    "selector": {
                      "type": "string"
                    },
                    "css": {
                      "type": "array",
                      "items": {
                        "type": "object",
                        "properties": {
                          "key": {
                            "type": "string",
                            "required": true
                          },
                          "value": {
                            "type": "string",
                            "required": true
                          }
                        }
                      }
                    }
                  }
                }
              }
            ]
          }
        }
      }
    }
```