### PR TITLE
Default values fix

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1114,11 +1114,10 @@ if (typeof brutusin === "undefined") {
                     renderTitle(titleContainer, propertyProvider.getValue(), s);
                 }
                 if (!value) {
-                    if (typeof initialValue !== "undefined" && initialValue !== null) {
-                        value = getInitialValue(id);
-                    } else {
-                        value = s.default;
-                    }
+                  value = s.default;
+                  if (typeof initialValue !== "undefined" && initialValue !== null) {
+                    value = getInitialValue(id) || value;
+                  }
                 }
                 r(container, id, parentObject, propertyProvider, value);
             }


### PR DESCRIPTION
Hi, it's me again ;)

I've fixed bug when Default values doesn't appear in whole form if some part of Initial Data exists

Say, we have schema: 
```
...
    "FOO": {
      "default": true,
      "type": "boolean"
    },
    "BAR": {
      "default": true,
      "type": "boolean"
    }
...
```

And if we haven't Initial Data at all, form will be rendered with those default values.
But if we have, say, only `{"BAR": true}` in Initial Data, the default values for `FOO` will not be shown.

It's because `getInitialValue(id)` will return `null` in this case.

This PR fixes it.