### PR TITLE
When enum length is 1, set selectedIndex to 0

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -204,7 +204,7 @@ if (typeof brutusin === "undefined") {
                     }
                 }
                 if (s.enum.length === 1)
-                    input.selectedIndex = 1;
+                    input.selectedIndex = 0;
                 else
                     input.selectedIndex = selectedIndex;
             } else {


### PR DESCRIPTION
When enum length is 1, set selectedIndex to 0  so that the only item in dropdown gets selected automatically.