### PR TITLE
`cleanSchemaMap` contained incorrect logic

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1311,7 +1311,7 @@ if (typeof brutusin === "undefined") {
 
         function cleanSchemaMap(schemaId) {
             for (var prop in schemaMap) {
-                if (schemaId.startsWith(prop)) {
+                if (prop.startsWith(schemaId)) {
                     delete schemaMap[prop];
                 }
             }


### PR DESCRIPTION
`cleanSchemaMap` contained incorrect logic, which caused some wierd issues when using dependencies inside arrays (and possibly deeper nested structures)