### PR TITLE
fix IE issue setting type to date

### DIFF
--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -130,7 +130,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
                 var tagName = element.tagName.toLowerCase();
                 if (tagName === "input" && schema.type === "string" && schema.format === format) {
                     if (inputType) {
-                        element.type = inputType;
+                        element.setAttribute("type", inputType);
                     }
                     if (glyphicon) {
                         var parent = element.parentNode;


### PR DESCRIPTION
Hello folks! It looks like IE blows up when you try to set `Element.type` directly as an input type that is unsupported (such as `"date"`). This change forces it to update the input type even if it's technically unsupported.

See the stack trace below:

![selection_010](https://user-images.githubusercontent.com/67489/30753445-4ddf7b3c-9f8d-11e7-9ecb-154149ec3c51.png)
