### PR TITLE
issue#90: email validation does not work

### DIFF
--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -277,6 +277,14 @@ if (typeof brutusin === "undefined") {
                                 return BrutusinForms.messages["maxLength"].format(s.maxLength);
                             }
                         }
+                        //Issue#90
+                        //Add a default regex pattern matching for email validation, or else user could use
+                        //the `pattern` field for their own custom regex pattern
+                        if (!s.pattern && s.format === "email") {
+                            if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
+                                return BrutusinForms.messages["email"];
+                            }
+                        }
                     }
                     if (value !== null && !isNaN(value)) {
                         if (s.multipleOf && value % s.multipleOf !== 0) {


### PR DESCRIPTION
**Issue: Email Validation does not work**

Description: When the input field is set to email, and an invalid email format is key in, it is able to pass the validation check.

Pic before change: 
![image](https://github.com/brutusin/json-forms/assets/137158566/f9454210-bb95-4b7e-a9db-ce25dcbbe5e7)


Pic after change:
![image](https://github.com/brutusin/json-forms/assets/137158566/02302071-6aca-412f-814e-ef7a64027ae2)
_Invalid email format_

![image](https://github.com/brutusin/json-forms/assets/137158566/eff77aa3-3966-4fc4-94d2-cf5ff5ffecff)
_Valid email format return validation succeed_
