### PR TITLE
Issue#37: add support for radio button

### DIFF
--- a/src/css/brutusin-json-forms.css
+++ b/src/css/brutusin-json-forms.css
@@ -64,7 +64,12 @@ form.brutusin-form table, form.brutusin-form input, form.brutusin-form select, f
     width: 100% !important;
     min-width: 80px;
 }
-form.brutusin-form input[type=checkbox]{
+
+form.brutusin-form input[type=radio] {
+    margin: 0 15px 0 10px;
+}
+
+form.brutusin-form input[type=checkbox], form.brutusin-form input[type=radio] {
     width: auto !important;
     min-width: auto !important;
 }

--- a/src/js/brutusin-json-forms-bootstrap.js
+++ b/src/js/brutusin-json-forms-bootstrap.js
@@ -33,7 +33,7 @@ if (("undefined" === typeof $ || "undefined" === typeof $.fn || "undefined" === 
     BrutusinForms.addDecorator(function (element, schema) {
         if (element.tagName) {
             var tagName = element.tagName.toLowerCase();
-            if (tagName === "input" && element.type !== "checkbox" || tagName === "textarea") {
+            if (tagName === "input" && (element.type !== "checkbox" && element.type !== "radio") || tagName === "textarea") {
                 element.className += " form-control";
             } else if (tagName === "select") {
                 element.className += " chosen-select form-control";

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -277,6 +277,13 @@ if (typeof brutusin === "undefined") {
                                 return BrutusinForms.messages["maxLength"].format(s.maxLength);
                             }
                         }
+                        //Add a default regex pattern matching for email validation, or else user could use
+                        //the `pattern` field for their own custom regex pattern
+                        if (!s.pattern && s.format === "email") {
+                            if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
+                                return BrutusinForms.messages["email"];
+                            }
+                        }
                     }
                     if (value !== null && !isNaN(value)) {
                         if (s.multipleOf && value % s.multipleOf !== 0) {

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -228,6 +228,8 @@ if (typeof brutusin === "undefined") {
                     input.type = "time";
                 } else if (s.format === "email") {
                     input.type = "email";
+                } else if (s.format === "password") {
+                    input.type = "password";
                 } else if (s.format === "text") {
                     input = document.createElement("textarea");
                 } else {

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -874,6 +874,10 @@ if (typeof brutusin === "undefined") {
                             }
                         }
                         var value = removeEmptiesAndNulls(object[prop], ss);
+                        //Check if user assign an empty String in the default field, if true return empty string instead of null
+                        if (ss.default == "" && value === null) {
+                            value = "";
+                        }
                         if (value !== null) {
                             clone[prop] = value;
                             nonEmpty = true;

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -1200,6 +1200,9 @@ if (typeof brutusin === "undefined") {
                 if (!value) {
                     if (typeof initialValue !== "undefined" && initialValue !== null) {
                         value = getInitialValue(id);
+                        if (value === null && typeof s.default !== "undefined") {
+                            value = s.default;
+                        }
                     } else {
                         value = s.default;
                     }

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -329,6 +329,9 @@ if (typeof brutusin === "undefined") {
                 input.title = s.description;
                 input.placeholder = s.description;
             }
+            if (s.class) {
+                input.className = s.class;
+            }
 //        if (s.pattern) {
 //            input.pattern = s.pattern;
 //        }
@@ -395,6 +398,9 @@ if (typeof brutusin === "undefined") {
             };
             input.schema = schemaId;
             input.id = getInputId();
+            if (s.class) {
+                input.className = s.class;
+            }
             inputCounter++;
             if (s.description) {
                 input.title = s.description;

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -252,9 +252,15 @@ if (typeof brutusin === "undefined") {
                             if (parentSchema && parentSchema.type === "object") {
                                 if (parentSchema.required) {
                                     return BrutusinForms.messages["required"];
+                                } else if (parentSchema.requiredProperties) {
+                                    for (var i = 0; i < parentSchema.requiredProperties.length; i++) {
+                                        if (parentSchema.requiredProperties[i] === s.$id.substring(2)) {
+                                            return BrutusinForms.messages["required"];
+                                        }
+                                    }
                                 } else {
                                     for (var prop in parentObject) {
-                                        if (parentObject[prop] !== null) {
+                                        if (parentObject[prop] === null) {
                                             return BrutusinForms.messages["required"];
                                         }
                                     }

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -277,6 +277,14 @@ if (typeof brutusin === "undefined") {
                                 return BrutusinForms.messages["maxLength"].format(s.maxLength);
                             }
                         }
+                        //Issue#90
+                        //Add a default regex pattern matching for email validation, or else user could use
+                        //the `pattern` field for their own custom regex pattern
+                        if (!s.pattern && s.format === "email") {
+                            if (!value.match(/[^@\s]+@[^@\s]+\.[^@\s]+/)) {
+                                return BrutusinForms.messages["email"];
+                            }
+                        }
                     }
                     if (value !== null && !isNaN(value)) {
                         if (s.multipleOf && value % s.multipleOf !== 0) {

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -76,6 +76,7 @@ if (typeof brutusin === "undefined") {
         "exclusiveMaximum": "Value must be **lower than** `{0}`",
         "minProperties": "At least `{0}` properties are required",
         "maxProperties": "At most `{0}` properties are allowed",
+        "email": "The email must at least consists an asterisk (@), following by a domain name with a dot (.)",
         "uniqueItems": "Array items must be unique",
         "addItem": "Add item",
         "true": "True",

--- a/src/js/brutusin-json-forms.js
+++ b/src/js/brutusin-json-forms.js
@@ -364,7 +364,29 @@ if (typeof brutusin === "undefined") {
             var schemaId = getSchemaId(id);
             var s = getSchema(schemaId);
             var input;
-            if (s.required) {
+            if (s.format === "radio") {
+                input = document.createElement("div");
+                for (var i = 0; i < s.enum.length; i++) {
+                    var radioInput = document.createElement("input");
+                    radioInput.type = "radio";
+                    radioInput.name = s.$id.substring(2);
+                    radioInput.value = s.enum[i];
+                    radioInput.id = s.enum[i];
+                    var label = document.createElement("label");
+                    label.htmlFor = s.enum[i];
+                    var labelText = document.createTextNode(s.enum[i]);
+                    appendChild(label, labelText);
+                    if (value && s.enum[i] === value) {
+                        radioInput.checked = true;
+                    }
+                    if (s.readOnly) {
+                        radioInput.disabled = true;
+                    }
+                    appendChild(input, label);
+                    appendChild(input, radioInput, s);
+                }
+            }
+            else if (s.required) {
                 input = document.createElement("input");
                 input.type = "checkbox";
                 if (value === true || value !== false && s.default) {


### PR DESCRIPTION
**Issue#37: Support for radio button inputs**

Link: [Issue#37](https://github.com/brutusin/json-forms/issues/37)

Description: Add support for radio button inputs, below is the schema used for generating a radio button. `format:radio` and `enum` is needed for generating radio buttons.

```
{
    "$schema": "http://json-schema.org/draft-03/schema#",
    "type": "object",
    "properties": {
        "pageSize": {
            "type": "boolean",
            "format": "radio",
            "title": "Page size",
            "description": "Number of records per page",
            "enum": [
                10,
                25,
                50,
                100
            ]
        }
    }
}
```

Pic before changes:
![image](https://github.com/brutusin/json-forms/assets/137158566/a17628ac-7320-40b0-925e-adfee1b62f86)
_Before having radio button support, it falls back to dropdown selection._

Pic after changes:
![image](https://github.com/brutusin/json-forms/assets/137158566/0c0c637e-6f7f-4a7b-8696-f5b8e703592f)
_After radio button format is implemented, now it is showing radio button._